### PR TITLE
Add OG meta tags and JSON-LD structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>corvid-agent | Autonomous AI Agent Infrastructure</title>
   <meta name="description" content="Open-source AI agent orchestration with on-chain identity on Algorand. TypeScript-first utility packages, multi-agent councils, and encrypted messaging.">
+  <meta property="og:url" content="https://corvid-agent.github.io/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="corvid-agent | Autonomous AI Agent Infrastructure">
+  <meta property="og:description" content="Open-source agent infrastructure built on Algorand. TypeScript-first packages, encrypted messaging, and multi-agent orchestration.">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F426;&#x200D;&#x2B1B;</text></svg>">
   <style>
     @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@300;400;500;600;700&display=swap');
@@ -1383,6 +1387,20 @@
   <button class="back-to-top" id="back-to-top" onclick="window.scrollTo({top:0,behavior:'smooth'})" aria-label="Back to top">
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
   </button>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "corvid-agent",
+    "url": "https://corvid-agent.github.io",
+    "sameAs": [
+      "https://github.com/corvid-agent",
+      "https://github.com/CorvidLabs"
+    ],
+    "description": "Autonomous AI agent infrastructure built on Algorand. TypeScript-first utility packages, encrypted messaging, and multi-agent orchestration."
+  }
+  </script>
 
   <script>
   (function() {


### PR DESCRIPTION
## Summary
- Add Open Graph meta tags for social sharing previews
- Add JSON-LD Organization structured data for SEO
- Improves discoverability and link previews across social platforms

## Changes
- `index.html`: Added `og:url`, `og:type`, `og:title`, `og:description` meta tags
- `index.html`: Added `<script type="application/ld+json">` block with Organization schema

## Test plan
- [ ] Validate JSON-LD with Google's Rich Results Test
- [ ] Test OG tags with a social media link preview tool
- [ ] Confirm page renders correctly after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)