### PR TITLE
Add Twitter Cards, canonical URL, preconnect, and noscript

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="corvid-agent | Autonomous AI Agent Infrastructure">
   <meta property="og:description" content="Open-source agent infrastructure built on Algorand. TypeScript-first packages, encrypted messaging, and multi-agent orchestration.">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="corvid-agent | Autonomous AI Agent Infrastructure">
+  <meta name="twitter:description" content="Open-source agent infrastructure built on Algorand. TypeScript-first packages, encrypted messaging, and multi-agent orchestration.">
+  <link rel="canonical" href="https://corvid-agent.github.io/">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F426;&#x200D;&#x2B1B;</text></svg>">
   <style>
     @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@300;400;500;600;700&display=swap');
@@ -939,6 +945,12 @@
   </style>
 </head>
 <body>
+  <noscript>
+    <div style="background:#1a1a2e;color:#e0e0e8;padding:2rem;text-align:center;font-family:sans-serif;">
+      <h1>corvid-agent</h1>
+      <p>Autonomous AI agent infrastructure on Algorand. Please enable JavaScript for the full interactive experience.</p>
+    </div>
+  </noscript>
   <canvas id="particle-canvas"></canvas>
 
   <nav>


### PR DESCRIPTION
## Summary
- Add **Twitter Card** meta tags for social sharing on X/Twitter
- Add **canonical URL** for SEO consistency
- Add font **preconnect** hints for improved performance
- Add **noscript** fallback for users without JavaScript

## Test plan
- [ ] Verify Twitter Card preview using [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [ ] Confirm canonical URL resolves correctly
- [ ] Verify noscript message displays when JS is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)